### PR TITLE
Removendo um warning sobre uma propriedade do iframe

### DIFF
--- a/src/components/prevention.js
+++ b/src/components/prevention.js
@@ -26,7 +26,7 @@ class Prevention extends Component {
                 papel para secá-las.
             Além do sabão, outro produto indicado para higienizar as mãos é o álcool gel 70%.</p>
               <div className="video-container">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/pt_zybIl7M4" frameborder="0" allowfullscreen>
+                <iframe title="video" width="560" height="315" src="https://www.youtube.com/embed/pt_zybIl7M4" frameborder="0" allowfullscreen>
                 </iframe>
               </div>
               {/* <a className="texto" rel='noopener noreferrer' target="_blank" href="https://www.youtube.com/watch?v=pt_zybIl7M4">Video</a> */}


### PR DESCRIPTION
Corrigi um warning sobre um iframe sem a propriedade title enquanto procurava o erro na aplicação, descobri alguns endpoints que não estão online, fazendo a aplicação não funcionar, acredito q devemos ver esses serciços ou fazer algum tratamento de erro para a tela principal n depender desses serviços